### PR TITLE
custom headers support

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -38,7 +38,15 @@ func (h *handler) HandleSign(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signed, err := h.tokenService.SignToken(payload)
+	// Extract headers from query parameters
+	headers := make(map[string]interface{})
+	for k, v := range r.URL.Query() {
+		if len(v) > 0 {
+			headers[k] = v[0]
+		}
+	}
+
+	signed, err := h.tokenService.SignToken(payload, headers)
 	if err != nil {
 		res := &ErrorResponse{Error: err.Error(), StatusCode: http.StatusBadRequest}
 		render.Render(w, r, res)

--- a/internal/token/token_test.go
+++ b/internal/token/token_test.go
@@ -97,7 +97,7 @@ func TestSignToken(t *testing.T) {
 		cfg := &config.JWK{Alg: jwa.RS256}
 		ts, _ := token.FromRawKey(raw, cfg)
 		payload := map[string]interface{}{"sub": "john-doe", "name": "John Doe"}
-		token, err := ts.SignToken(payload)
+		token, err := ts.SignToken(payload, nil)
 		decoded, _ := jwt.Parse(token, jwt.WithKey(cfg.Alg, raw))
 
 		assert.NoError(t, err)
@@ -112,7 +112,7 @@ func TestSignToken(t *testing.T) {
 		cfg := &config.JWK{Alg: jwa.RS256}
 		ts, _ := token.FromRawKey(raw, cfg)
 		payload := map[string]interface{}{"iat": "invalid"}
-		token, err := ts.SignToken(payload)
+		token, err := ts.SignToken(payload, nil)
 
 		assert.Nil(t, token)
 		assert.Error(t, err)


### PR DESCRIPTION
It's often required to add custom headers to JWT. With PR allows to add such headers with query parameters of /sign handler